### PR TITLE
Add Rustdesk Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Personal Server Applications
+This repo is for all applications that will rnu on my personal server at Digial Ocean (called `apollo`). It consists of a `docker-compose.yaml` defining the services I want as well as some configuration and some helper scripts.
+
+## Updating Services After Changes
+1) Log into the console for `apollo` through Digital Ocean
+2) Navigate to the repo's directory.
+```
+cd Influxdb-Grafana-Docker-Compose
+```
+3) Pull latest changes from github (or switch to the new branch and pull)
+```
+git pull origin master
+```
+4) Stop and start the apps.
+```
+bash stop-app.sh
+bash start-app.sh
+```

--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ git pull origin master
 bash stop-app.sh
 bash start-app.sh
 ```
+
+## Secrets
+Secrets are stored in a file called `.env` in the root of the repository. It isn't tracked by git for security reasons. This file should really only exist on the server. Environment variables defined there can be accessed through in `docker-compose.yaml` with the syntax `${YOUR_SECRET_HERE}`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Personal Server Applications
-This repo is for all applications that will rnu on my personal server at Digial Ocean (called `apollo`). It consists of a `docker-compose.yaml` defining the services I want as well as some configuration and some helper scripts.
+This repo is for all applications that will run on my personal server at Digial Ocean (called `apollo`). It consists of a `docker-compose.yaml` defining the services I want as well as some configuration and some helper scripts.
 
 ## Updating Services After Changes
 1) Log into the console for `apollo` through Digital Ocean

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,7 +93,3 @@ volumes:
   certbot_acme_challenge:
   influxdb-storage-etc:
   rustdesk-db:
-
-networks:
-  rustdesk-net:
-    external: false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
       - 21119:21119
     image: rustdesk/rustdesk-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=rustdesk.chris-pierce.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
       - "KEY_PRIV=${RUSTDESK_KEY_PRIV}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,25 @@ services:
       INFLUX_USER: ${INFLUX_USER}
       INFLUX_PASSWORD: ${INFLUX_PASSWORD}
 
+  rustdesk-server:
+    container_name: rustdesk-server
+    ports:
+      - 21115:21115
+      - 21116:21116
+      - 21116:21116/udp
+      - 21117:21117
+      - 21118:21118
+      - 21119:21119
+    image: rustdesk/rustdesk-server-s6:latest
+    environment:
+      - "RELAY=rustdesk.example.com:21117"
+      - "ENCRYPTED_ONLY=1"
+      - "DB_URL=/db/db_v2.sqlite3"
+      - "KEY_PRIV=${RUSTDESK_KEY_PRIV}"
+      - "KEY_PUB=${RUSTDESK_KEY_PUB}"
+    volumes:
+      - rustdesk-db:/db
+    restart: unless-stopped
       
 volumes:
   grafana-storage:
@@ -73,3 +92,8 @@ volumes:
   letsencrypt_certs:
   certbot_acme_challenge:
   influxdb-storage-etc:
+  rustdesk-db:
+
+networks:
+  rustdesk-net:
+    external: false


### PR DESCRIPTION
This PR adds rustdesk server to `docker-compose.yaml`. Also added is a README file. This seems to be working correctly and I tested logging into my home computer through it. I also tried logging in with the wrong key and it successfully rejected me.